### PR TITLE
chore: security dependency updates

### DIFF
--- a/TheBugTracker.csproj
+++ b/TheBugTracker.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.0" />
+    <PackageReference Include="MailKit" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="10.0.0" />
@@ -56,7 +56,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MimeKit" Version="4.15.1" />
+    <PackageReference Include="MimeKit" Version="4.17.0" />
     <PackageReference Include="Npgsql" Version="10.0.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Bumps MailKit 4.15.0 → 4.17.0 to resolve moderate advisory GHSA-9j88-vvj5-vhgr.

MimeKit is bumped 4.15.1 → 4.17.0 as well, since MailKit 4.17.0 depends on MimeKit 4.17.0.

Verified with `dotnet build` (build succeeded, 0 warnings/errors) and `dotnet list package --vulnerable --include-transitive` reports no vulnerable packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)